### PR TITLE
Support remote ollama models

### DIFF
--- a/backend-agent/llm.py
+++ b/backend-agent/llm.py
@@ -352,9 +352,9 @@ class OllamaLLM(LLM):
     def generate(self,
                  system_prompt: str,
                  prompt: str,
-                 temperature: float,
-                 max_tokens: int,
-                 n: int) -> list[str]:
+                 max_tokens: int = 4096,
+                 temperature: float = 0.3,
+                 n: int = 1,) -> list[str]:
         try:
             messages = [
                 {'role': 'system', 'content': system_prompt},

--- a/backend-agent/requirements.txt
+++ b/backend-agent/requirements.txt
@@ -17,7 +17,7 @@ tensorflow-hub
 sentence-transformers
 torchfile
 tensorflow-text
-ollama==0.4.2
+ollama==0.4.7
 weasyprint
 pyrit==0.2.1
 textattack>=0.3.10


### PR DESCRIPTION
Models can be accessed via ollama not only on localhost but also when deployed on remote hosts.

From the host side: it requires serving ollama on `0.0.0.0` instead of `localhost`, for example following [this strategy](https://github.com/ollama/ollama/issues/703) or [this one](https://github.com/ollama/ollama/issues/5905)