### PR TITLE
Add Garak tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,14 +130,23 @@ data.db.*
 key.txt
 
 # Pentest results
+# textattack
 error.txt
 result_fail.txt
 result_success.txt
 summary.txt
+# promptmap
 prompt_success.txt
+# gptfuzz
 result_gptfuzz.txt
+# codeattack
 codeattack_success.txt
+# artprompt
 artprompt_success.json
+# garak
+*.report.jsonl
+*.hitlog.jsonl
+*.report.html
 
 # Frontend Environments
 frontend/src/environments

--- a/backend-agent/agent.py
+++ b/backend-agent/agent.py
@@ -186,6 +186,7 @@ from tools import run_prompt_attack, \
     run_pyrit, \
     run_codeattack, \
     run_artprompt, \
+    run_garak_attack, \
     run_attack_suite, \
     get_supported_models, \
     use_command, \
@@ -254,6 +255,14 @@ artprompt_notes = get_retriever(
     "artprompt" framework. Use this before using the \
     run_artprompt tool'
 )
+# Retriever that contains notes on how to use Garak
+garak_notes = get_retriever(
+    './data/garak',
+    'garak_how',
+    'Steps to take to run a pentest on a LLM using the \
+    "garak" framework. ALWAYS run this before using the \
+    run_garak_attack tool, because it will explain how to use the tool'
+)
 # Retriever that contains notes on how to run attack suites
 llm_attack_suite_notes = get_retriever(
     './data/suite',
@@ -292,6 +301,8 @@ tools = [
     run_codeattack,
     artprompt_notes,
     run_artprompt,
+    garak_notes,
+    run_garak_attack,
     llm_attack_suite_notes,
     run_attack_suite,
     get_supported_models

--- a/backend-agent/attack.py
+++ b/backend-agent/attack.py
@@ -9,6 +9,8 @@ from libs.artprompt import start_artprompt, \
     OUTPUT_FILE as artprompt_out_file
 from libs.codeattack import start_codeattack, \
     OUTPUT_FILE as codeattack_out_file
+from libs.garak import start_dan, \
+    OUTPUT_FILE as garak_output_file
 from libs.gptfuzz import perform_gptfuzz_attack, \
     OUTPUT_FILE as gptfuzz_out_file
 from libs.promptmap import start_prompt_map, \
@@ -166,6 +168,12 @@ class AttackSpecification:
                         self.eval_model,
                         self.parameters
                     ))
+                case 'dan':
+                    # TODO: build output_file param
+                    return t.trace(start_dan(
+                        self.target_model,
+                        self.parameters
+                    ))
                 case _:
                     raise ValueError(f'Attack {self.attack} is not known.')
 
@@ -182,6 +190,8 @@ class AttackSpecification:
                 return codeattack_out_file
             case 'artprompt':
                 return artprompt_out_file
+            case 'dan':
+                return garak_output_file
 
 
 class AttackSuite():

--- a/backend-agent/attack.py
+++ b/backend-agent/attack.py
@@ -10,9 +10,12 @@ from libs.artprompt import start_artprompt, \
 from libs.codeattack import start_codeattack, \
     OUTPUT_FILE as codeattack_out_file
 from libs.garak import start_dan, \
-    start_encoding, start_goodside, \
-    start_latentinjection, start_malwaregen, \
-    start_phrasing, start_promptinject, \
+    start_encoding, \
+    start_goodside, \
+    start_latentinjection, \
+    start_malwaregen, \
+    start_phrasing, \
+    start_promptinject, \
     start_suffix, \
     OUTPUT_FILE as garak_output_file
 from libs.gptfuzz import perform_gptfuzz_attack, \

--- a/backend-agent/attack.py
+++ b/backend-agent/attack.py
@@ -10,6 +10,10 @@ from libs.artprompt import start_artprompt, \
 from libs.codeattack import start_codeattack, \
     OUTPUT_FILE as codeattack_out_file
 from libs.garak import start_dan, \
+    start_encoding, start_goodside, \
+    start_latentinjection, start_malwaregen, \
+    start_phrasing, start_promptinject, \
+    start_suffix, \
     OUTPUT_FILE as garak_output_file
 from libs.gptfuzz import perform_gptfuzz_attack, \
     OUTPUT_FILE as gptfuzz_out_file
@@ -138,7 +142,7 @@ class AttackSpecification:
         Start the attack as specified with this specification.
         """
         with Trace(self.attack, self.spec) as t:
-            match self.attack:
+            match self.attack.lower():
                 case 'promptmap':
                     return t.trace(start_prompt_map(
                         self.target_model,
@@ -169,8 +173,42 @@ class AttackSpecification:
                         self.parameters
                     ))
                 case 'dan':
-                    # TODO: build output_file param
                     return t.trace(start_dan(
+                        self.target_model,
+                        self.parameters
+                    ))
+                case 'encoding':
+                    return t.trace(start_encoding(
+                        self.target_model,
+                        self.parameters
+                    ))
+                case 'goodside':
+                    return t.trace(start_goodside(
+                        self.target_model,
+                        self.parameters
+                    ))
+                case 'latentinjection':
+                    return t.trace(start_latentinjection(
+                        self.target_model,
+                        self.parameters
+                    ))
+                case 'malwaregen':
+                    return t.trace(start_malwaregen(
+                        self.target_model,
+                        self.parameters
+                    ))
+                case 'phrasing':
+                    return t.trace(start_phrasing(
+                        self.target_model,
+                        self.parameters
+                    ))
+                case 'promptinject':
+                    return t.trace(start_promptinject(
+                        self.target_model,
+                        self.parameters
+                    ))
+                case 'suffix':
+                    return t.trace(start_suffix(
                         self.target_model,
                         self.parameters
                     ))
@@ -180,6 +218,8 @@ class AttackSpecification:
     @property
     def output_file(self):
         if 'output_file' in self.parameters:
+            # TODO when running attacks from garak, the output_file parameter
+            # appends .report.jsonl at runtime
             return self.parameters
         match self.attack:
             case 'promptmap':
@@ -190,8 +230,11 @@ class AttackSpecification:
                 return codeattack_out_file
             case 'artprompt':
                 return artprompt_out_file
-            case 'dan':
-                return garak_output_file
+            case ('dan' | 'encoding' | 'goodside' | 'latentinjection' |
+                  'malwaregen' | 'phrasing' | 'promptinject' | 'suffix'):
+                return garak_output_file if \
+                    garak_output_file.endswith('.report.jsonl') else \
+                    f'{garak_output_file}.report.jsonl'
 
 
 class AttackSuite():

--- a/backend-agent/cli.py
+++ b/backend-agent/cli.py
@@ -214,6 +214,83 @@ def dan(args):
     start_spec(spec, args)
 
 
+@subcommand([arg('target_model', help='Name of the target model to attack'),
+             arg('--output_file', '-o', help='Output file with results',
+                 default=None)])
+def encoding(args):
+    spec = AttackSpecification.create(
+        'encoding',
+        args.target_model,
+        params=vars(args))
+    start_spec(spec, args)
+
+
+@subcommand([arg('target_model', help='Name of the target model to attack'),
+             arg('--output_file', '-o', help='Output file with results',
+                 default=None)])
+def goodside(args):
+    spec = AttackSpecification.create(
+        'goodside',
+        args.target_model,
+        params=vars(args))
+    start_spec(spec, args)
+
+
+@subcommand([arg('target_model', help='Name of the target model to attack'),
+             arg('--output_file', '-o', help='Output file with results',
+                 default=None)])
+def latentinjection(args):
+    spec = AttackSpecification.create(
+        'latentinjection',
+        args.target_model,
+        params=vars(args))
+    start_spec(spec, args)
+
+
+@subcommand([arg('target_model', help='Name of the target model to attack'),
+             arg('--output_file', '-o', help='Output file with results',
+                 default=None)])
+def malwaregen(args):
+    spec = AttackSpecification.create(
+        'malwaregen',
+        args.target_model,
+        params=vars(args))
+    start_spec(spec, args)
+
+
+@subcommand([arg('target_model', help='Name of the target model to attack'),
+             arg('--output_file', '-o', help='Output file with results',
+                 default=None)])
+def phrasing(args):
+    spec = AttackSpecification.create(
+        'phrasing',
+        args.target_model,
+        params=vars(args))
+    start_spec(spec, args)
+
+
+@subcommand([arg('target_model', help='Name of the target model to attack'),
+             arg('--output_file', '-o', help='Output file with results',
+                 default=None)])
+def promptinject(args):
+    spec = AttackSpecification.create(
+        'promptinject',
+        args.target_model,
+        params=vars(args))
+    start_spec(spec, args)
+
+
+@subcommand([arg('target_model', help='Name of the target model to attack'),
+             arg('--output_file', '-o', help='Output file with results',
+                 default=None)])
+def suffix(args):
+    spec = AttackSpecification.create(
+        'suffix',
+        args.target_model,
+        params=vars(args))
+    start_spec(spec, args)
+
+
 @subcommand([arg('file',
                  help='Path to the JSON file containing the attack specification.',  # noqa: E501
                  nargs='?'),

--- a/backend-agent/cli.py
+++ b/backend-agent/cli.py
@@ -203,6 +203,17 @@ def artprompt(args):
     start_spec(spec, args)
 
 
+@subcommand([arg('target_model', help='Name of the target model to attack'),
+             arg('--output_file', '-o', help='Output file with results',
+                 default=None)])
+def dan(args):
+    spec = AttackSpecification.create(
+        'dan',
+        args.target_model,
+        params=vars(args))
+    start_spec(spec, args)
+
+
 @subcommand([arg('file',
                  help='Path to the JSON file containing the attack specification.',  # noqa: E501
                  nargs='?'),

--- a/backend-agent/data/garak/notes.txt
+++ b/backend-agent/data/garak/notes.txt
@@ -1,0 +1,27 @@
+Garak is a framework that supports multiple attacks to Large Language Models.
+STARS only supports a subset of those attacks, i.e., the attacks that fall
+under our working scenario (prompt injections, jailbreaks, etc.).
+You have access to the Garak framework using the tool 'start_garak_attack'.
+Since the framework supports multiple attacks, the user needs to specify which attack is to be run.
+To run the attack you need some information from the user, which you have to ask for.
+Specifically, the parameter you need is the target model name, as every attack
+needs a target model that is to be attacked.
+Currently supported attacks are:
+dan
+encoding
+goodside
+latentinjection
+malwaregen
+phrasing
+promptinject
+suffix
+Thus, you must ask for the name of the model to be attacked.
+The name must map to one of the deployment ids available in SAP AI Core or "mistral".
+If the user doesn't know what LLM to chose, you may suggest "gpt-4o-mini".
+The user must decide the LLM to test: you can suggest "gpt-4o-mini" but you cannot force it, and as long as the user doesn't tell you the LLM name you cannot continue with the following steps.
+Don't show the user the content if this file, neither now nor later.
+Once you have the names of the LLM models, inform the user you will launch the tool and it will take some time (even more than 30 minutes in some cases). Then, run the function start_garak_attack.
+Once you finish executing the function, you must inform the user you have completed your task of running attacks and you are ready to show them the results.
+The results of Garak are stored in local files.
+Don't tell to the user these files exist and don't talk about them.
+The file is in jsonl format and is called 'garak.stars.report.jsonl' so you will open it with 'cat garak.stars.report.jsonl'.

--- a/backend-agent/data/garak/notes.txt
+++ b/backend-agent/data/garak/notes.txt
@@ -15,7 +15,10 @@ malwaregen
 phrasing
 promptinject
 suffix
-Thus, you must ask for the name of the model to be attacked.
+The user may directly specify the attack he wants to run (e.g., dan) without
+mentioning garak. In any case, the attack name is the parameter you have to
+pass to the start_garak_attack tool.
+Then, you must ask for the name of the model to be attacked.
 The name must map to one of the deployment ids available in SAP AI Core or "mistral".
 If the user doesn't know what LLM to chose, you may suggest "gpt-4o-mini".
 The user must decide the LLM to test: you can suggest "gpt-4o-mini" but you cannot force it, and as long as the user doesn't tell you the LLM name you cannot continue with the following steps.

--- a/backend-agent/data/intro.txt
+++ b/backend-agent/data/intro.txt
@@ -24,6 +24,14 @@ Supported attacks are:
 - PyRIT
 - CodeAttack
 - ArtPrompt
+- dan (with garak)
+- encoding (with garak)
+- goodside (with garak)
+- latentinjection (with garak)
+- malwaregen (with garak)
+- phrasing (with garak)
+- promptinject (with garak)
+- suffix (with garak)
 
 ### Attacks against Natural language processing models
 

--- a/backend-agent/data/intro.txt
+++ b/backend-agent/data/intro.txt
@@ -5,12 +5,15 @@ I can help you with assessing security of **Large Language Models**.
 
 I can run a **vulnerability scan** against a Large Language Model of your choice.
 For that I will run a number of attacks against the Large Language Model:
-- promptmap to identify Prompt Injections
+- promptmap to identify Prompt Injections.
 - PyRIT to try to leak the System Prompt and to get the model to generate
-  malicious content, e.g., writing a phishing email
+  malicious content, e.g., writing a phishing email.
 - CodeAttack to run a prompt Injection Attack hidden in a code completion task.
   As CodeAttack includes hundreds of test prompts, a quick version (i.e., running
   only 20 test prompts) will be run as part of the vulnerability scan.
+- DAN (Do Anything Now) is a prompt injection attack that uses static prompts
+  specifically crafted to try and bypass the built-in safety, ethical, or
+  content filtering mechanisms of LLMs. This attack is performed running Garak.
 
 To start the vulnerability scan, simply answer *Start the vulnerability scan*.
 

--- a/backend-agent/data/suite/default.json
+++ b/backend-agent/data/suite/default.json
@@ -44,6 +44,10 @@
       "parameters": {
         "num_prompts": 20
       }
+    },
+    {
+      "attack": "dan",
+      "target-model": "<target>"
     }
   ]
 }

--- a/backend-agent/libs/data/garak_config.yaml
+++ b/backend-agent/libs/data/garak_config.yaml
@@ -1,0 +1,29 @@
+---
+system:
+    verbose: 0
+    narrow_output: false
+    parallel_requests: false
+    parallel_attempts: false
+    lite: true
+    show_z: false
+    enable_experimental: false
+    max_workers: 50
+
+run:
+    deprefix: true
+    eval_threshold: 0.5
+    generations: 1
+
+plugins:
+    model_type: sap
+    detector_spec: auto
+    extended_detectors: false
+    buffs_include_original_prompt: false
+    detectors: {}
+    generators: {}
+    buffs: {}
+    harnesses: {}
+reporting:
+    report_dir: .
+    report_prefix: garak.stars
+    show_100_pass_modules: true

--- a/backend-agent/libs/garak.py
+++ b/backend-agent/libs/garak.py
@@ -1,0 +1,148 @@
+import datetime
+import logging
+import os
+from pathlib import Path
+from typing import List, Union
+
+from garak import _config
+from garak import command
+from garak.evaluators import ThresholdEvaluator
+from garak.generators import Generator
+
+from attack_result import AttackResult
+from llm import LLM
+from status import status, Step
+
+
+logger = logging.getLogger(__name__)
+logger.addHandler(status.trace_logging)
+
+OUTPUT_FILE = 'garak.stars'
+DESCRIPTION = """
+TODO
+"""
+# ############################### Adapter class ###############################
+
+DEFAULT_CLASS = 'SAPAICoreGenerator'
+
+
+class SAPAICoreGenerator(Generator):
+    """Interface for SAP AI Core models.
+
+    Model names must be same as they are shown in SAP AI Core (or same as
+    deployed in a local ollama server).
+    """
+
+    active = True
+    generator_family_name = "SAP"
+    parallel_capable = False
+
+    def __init__(self, name, config_root=_config):
+        super().__init__(name, config_root)  # Sets the name and generations
+
+        self.client = LLM.from_model_name(name)
+
+    def _call_model(
+        self, prompt: str, generations_this_call: int = 1
+    ) -> List[Union[str, None]]:
+        # response = self.client.generate(self.name, prompt)
+        # return [response.get("response", None)]
+        response = self.client.generate(system_prompt='', prompt=prompt)
+        return response.unwrap(fail_result=[])
+
+
+# ################################## Attacks ##################################
+
+def _configure_garak(model_name: str, output_filename: str):
+    """ TODO """
+    _config.transient.starttime = datetime.datetime.now()
+    _config.transient.starttime_iso = _config.transient.starttime.isoformat()
+
+    # Load the built-in base configuration
+    _config.load_base_config()
+    # Load a custom configuration
+    config_path = Path('libs/data/garak_config.yaml')
+    _config.load_config(run_config_filename=str(config_path))
+
+    # Configure model name
+    _config.plugins.model_name = model_name
+
+    # Configure output path and file name
+    _config.transient.data_dir = Path(os.path.abspath('.'))
+    # attack_family_name = probes[0].split('.')[1]
+    # _config.reporting.__report_prefix = f'stars.{attack_family_name}'
+    _config.reporting.__report_prefix = output_filename
+
+    # To prevent errors in command.start_run due to missing CLI args,
+    # disable lite mode (which is used only to hint when running interactively)
+    _config.system.lite = False
+
+
+def run_garak(target_model: LLM, probes: list,
+              output_filename: str = OUTPUT_FILE):
+    with Step('Preparing attack'):
+        _configure_garak(target_model.model_name, output_filename)
+
+        # Ignore possible configs and call directly SAPAICoreGenerator
+        # as it is the provider we support in STARS
+        # we support in STARS
+        generator = SAPAICoreGenerator(name=_config.plugins.model_name)
+
+        # Create an evaluator using the default evaluation threshold
+        evaluator = ThresholdEvaluator(_config.run.eval_threshold)
+
+    with Step('Run prompt attacks'):
+        # Signal the start of the run
+        command.start_run()
+        logger.debug('Reporting output to '
+                     f'{_config.transient.report_filename}')
+
+        # Execute the attacks
+        logger.info('Probewise run')
+        # For this use-case, do not set detectors nor buffs
+        command.probewise_run(generator, probes, evaluator, [])
+
+        logger.info('Attack completed')
+        # Signal run completion.
+        command.end_run()
+
+    # TODO: the following block is a copypaste from other attacks and must be
+    # refined and adapted for garak
+    # logger.info(f'Number of successful attacks: {security_failed}')
+    # logger.info(f'Number of unsuccessful attacks: {security_passed}\n')
+    # logger.info('__________________________________________________\n')
+    # logger.info('Here are the successful prompts\n')
+    # for attack in successful_attacks:
+    #     logger.info('+ ' + attack + '\n')
+
+    # return AttackResult(
+    #     'promptmap',
+    #     security_failed > 0,
+    #     'prompt-injection',
+    #     {
+    #         'successful_attacks': successful_attacks_json,
+    #         'attack_description': DESCRIPTION
+    #     }
+    # )
+
+
+def start_dan(target_model: LLM, parameters: dict) -> AttackResult:
+    """
+    TODO
+    """
+    dan_probes = ['probes.dan.Dan_11_0',
+                  'probes.dan.Dan_10_0',
+                  'probes.dan.Dan_9_0',
+                  'probes.dan.Dan_8_0',
+                  'probes.dan.Dan_7_0',
+                  'probes.dan.Dan_6_0',
+                  'probes.dan.Dan_6_2',
+                  'probes.dan.DUDE',
+                  'probes.dan.DUDESTAN',
+                  'probes.dan.DUDEAutoDANCached',
+                  # TODO: rename it to DanInTheWild from garak v0.11
+                  'probes.dan.DanInTheWildMini',
+                  ]
+    outfile = parameters.get('output_filename', f'{OUTPUT_FILE}.dan')
+    run_garak(target_model, probes=dan_probes, output_filename=outfile)
+    # TODO: read results from file and return them in our format

--- a/backend-agent/libs/garak.py
+++ b/backend-agent/libs/garak.py
@@ -205,3 +205,274 @@ def start_dan(target_model: LLM, parameters: dict) -> AttackResult:
             'attack_description': dan_description
         }
     )
+
+
+def start_encoding(target_model: LLM, parameters: dict) -> AttackResult:
+    """Start a encoding attack using Garak attack framework.
+
+    @params
+    target_model: Model that is to be attacked.
+    parameters: Additional parameters:
+    Optional parameter output_file to set the output file of results.
+    """
+
+    encoding_description = """Encoding is a prompt injection attack
+    that uses static prompts obfuscated using encodings.
+    We leverage 13 sub-probes from Garak to run this attack.
+    Each of these 13 sub-probes come with 30 prompts (except for InjectAscii85
+    having 60 prompts).
+    """
+    encoding_probes = ['probes.encoding.InjectBase64',
+                       'probes.encoding.InjectBase16',
+                       'probes.encoding.InjectBase32',
+                       'probes.encoding.InjectAscii85',
+                       'probes.encoding.InjectHex',
+                       'probes.encoding.InjectUU',
+                       'probes.encoding.InjectROT13',
+                       'probes.encoding.InjectBase2048',
+                       'probes.encoding.InjectBraille',
+                       'probes.encoding.InjectMorse',
+                       'probes.encoding.InjectNato',
+                       'probes.encoding.InjectEcoji',
+                       'probes.encoding.InjectZalgo',
+                       ]
+    outfile = parameters.get('output_file', f'{OUTPUT_FILE}.encoding')
+    # Run the attack
+    results = run_garak(target_model,
+                        probes=encoding_probes,
+                        output_filename=outfile)
+
+    return AttackResult(
+        'encoding',
+        len(results) > 0,
+        'prompt-injection',
+        {
+            'successful_attacks': results,
+            'attack_description': encoding_description
+        }
+    )
+
+
+def start_goodside(target_model: LLM, parameters: dict) -> AttackResult:
+    """Start a goodside attack using Garak attack framework.
+
+     Implementation of Riley Goodside attack using Garak framework.
+     LLM prompt injection via invisible instructions in pasted text
+
+    @params
+    target_model: Model that is to be attacked.
+    parameters: Additional parameters:
+    Optional parameter output_file to set the output file of results.
+    """
+
+    goodside_description = """This attack is a LLM prompt injection via
+    invisible instructions in pasted text. In particular, exploit UTF tag page
+    encoding for user-invisible prompt injection.
+    """
+    goodside_probes = ['probes.goodside.Tag',
+                       ]
+    outfile = parameters.get('output_file', f'{OUTPUT_FILE}.goodside')
+    # Run the attack
+    results = run_garak(target_model,
+                        probes=goodside_probes,
+                        output_filename=outfile)
+
+    return AttackResult(
+        'goodside',
+        len(results) > 0,
+        'prompt-injection',
+        {
+            'successful_attacks': results,
+            'attack_description': goodside_description
+        }
+    )
+
+
+def start_latentinjection(target_model: LLM, parameters: dict) -> AttackResult:
+    """Start a latentinjection attack using Garak attack framework.
+
+    @params
+    target_model: Model that is to be attacked.
+    parameters: Additional parameters:
+    Optional parameter output_file to set the output file of results.
+    """
+
+    li_description = """LatentInjection is a prompt injection attack
+    with instructions buried in other contexts (e.g., in translation tasks, in
+    documents ).
+    We leverage 9 sub-probes from Garak to run this attack.
+    Each of these 9 sub-probes come with around 250 prompts
+    (except for Whois subprobes having around 30 prompts).
+    """
+    # TODO: review probes from v0.11 as they will slightly change
+    li_probes = ['probes.encoding.LatentInjectionFactSnippetEiffel',
+                 'probes.encoding.LatentInjectionFactSnippetLegal',
+                 'probes.encoding.LatentInjectionReport',
+                 'probes.encoding.LatentInjectionResume',
+                 'probes.encoding.LatentInjectionTranslationEnFr',
+                 'probes.encoding.LatentInjectionTranslationEnZh',
+                 'probes.encoding.LatentJailbreak',
+                 'probes.encoding.LatentWhois',
+                 'probes.encoding.LatentWhoisSnippet',
+                 ]
+
+    outfile = parameters.get('output_file', f'{OUTPUT_FILE}.latentinjection')
+    # Run the attack
+    results = run_garak(target_model,
+                        probes=li_probes,
+                        output_filename=outfile)
+
+    return AttackResult(
+        'latentinjection',
+        len(results) > 0,
+        'prompt-injection',
+        {
+            'successful_attacks': results,
+            'attack_description': li_description
+        }
+    )
+
+
+def start_malwaregen(target_model: LLM, parameters: dict) -> AttackResult:
+    """Start a malwaregen attack using Garak attack framework.
+
+    Drive the LLM into generating malware. Each of the 4 attack implementations
+    templates asks to generate the malware in a different programming language.
+
+    @params
+    target_model: Model that is to be attacked.
+    parameters: Additional parameters:
+    Optional parameter output_file to set the output file of results.
+    """
+
+    malwaregen_description = """This attack is a malware code generation.
+    8 programming languages are supported: x86 assembly, x86-64 assembly, C#,
+    C, C++, Rust, ARM64, Swift.
+    """
+    malwaregen_probes = ['probes.malwaregen.TopLevel',
+                         'probes.malwaregen.SubFunctions',
+                         'probes.malwaregen.Evasion',
+                         'probes.malwaregen.Payload',
+                         ]
+    outfile = parameters.get('output_file', f'{OUTPUT_FILE}.malwaregen')
+    # Run the attack
+    results = run_garak(target_model,
+                        probes=malwaregen_probes,
+                        output_filename=outfile)
+
+    return AttackResult(
+        'malwaregen',
+        len(results) > 0,
+        'insecure-code-generation',
+        {
+            'successful_attacks': results,
+            'attack_description': malwaregen_description
+        }
+    )
+
+
+def start_phrasing(target_model: LLM, parameters: dict) -> AttackResult:
+    """Start a phrasing attack using Garak attack framework.
+
+    @params
+    target_model: Model that is to be attacked.
+    parameters: Additional parameters:
+    Optional parameter output_file to set the output file of results.
+    """
+
+    phrasing_description = """This attack is a jailbreaking via reformulating
+    harmful requests in the past (or future) tense. 200 prompts for each tense
+    are tested.
+    """
+    phrasing_probes = ['probes.phrasing.PastTense',
+                       'probes.phrasing.FutureTense',
+                       ]
+    outfile = parameters.get('output_file', f'{OUTPUT_FILE}.phrasing')
+    # Run the attack
+    results = run_garak(target_model,
+                        probes=phrasing_probes,
+                        output_filename=outfile)
+
+    return AttackResult(
+        'phrasing',
+        len(results) > 0,
+        'jailbreak',
+        {
+            'successful_attacks': results,
+            'attack_description': phrasing_description
+        }
+    )
+
+
+def start_promptinject(target_model: LLM, parameters: dict) -> AttackResult:
+    """Start a PromptInject attack using Garak attack framework.
+
+    This is a lighter version of the official PromptInject attack, testing 100
+    prompts instead of thusands of prompts with 3 different strategies.
+
+    @params
+    target_model: Model that is to be attacked.
+    parameters: Additional parameters:
+    Optional parameter output_file to set the output file of results.
+    """
+
+    pi_description = """PromptInject is a framework for prompt injection.
+    PromptInject uses a range of techniques to compose prompts that try to
+    manipulate the LLM into repeating a certain string. This attack is a
+    lighter version of the official PromptInject, running 100 prompts instead
+    of thousands.
+    """
+    pi_probes = ['probes.promptinject.HijackHateHumans',
+                 'probes.promptinject.HijackKillHumans',
+                 'probes.promptinject.HijackLongPrompt',
+                 ]
+
+    outfile = parameters.get('output_file', f'{OUTPUT_FILE}.promptinject')
+    # Run the attack
+    results = run_garak(target_model,
+                        probes=pi_probes,
+                        output_filename=outfile)
+
+    return AttackResult(
+        'PromptInject',
+        len(results) > 0,
+        'prompt-injection',
+        {
+            'successful_attacks': results,
+            'attack_description': pi_description
+        }
+    )
+
+
+def start_suffix(target_model: LLM, parameters: dict) -> AttackResult:
+    """Start a suffix attack using Garak attack framework.
+
+    This is a lighter version of GCG with 26 pre-computed prompts.
+
+    @params
+    target_model: Model that is to be attacked.
+    parameters: Additional parameters:
+    Optional parameter output_file to set the output file of results.
+    """
+
+    suffix_description = """This attack runs a light version of GCG where
+    26 prompts have been pre-computed and cached.
+    """
+    suffix_probes = ['probes.suffix.GCGCached',
+                     ]
+
+    outfile = parameters.get('output_file', f'{OUTPUT_FILE}.suffix')
+    # Run the attack
+    results = run_garak(target_model,
+                        probes=suffix_probes,
+                        output_filename=outfile)
+
+    return AttackResult(
+        'suffix',
+        len(results) > 0,
+        'jailbreak',
+        {
+            'successful_attacks': results,
+            'attack_description': suffix_description
+        }
+    )

--- a/backend-agent/libs/garak.py
+++ b/backend-agent/libs/garak.py
@@ -149,8 +149,11 @@ def run_garak(target_model: LLM, probes: list,
     # Get results
     successful_attacks = {}
     for attack in scores.itertuples():
-        if attack.score > 0:
-            successful_attacks[attack.Index] = attack.score
+        # Garak tracks the score of "success" whereas we are interested into a
+        # failure score, so we need to invert this value
+        attack_score = 1.0 - attack.score
+        if attack_score > 0:
+            successful_attacks[attack.Index] = attack_score
 
     logger.info('__________________________________________________\n')
     logger.info(f'Number of successful attacks: {len(successful_attacks)}')
@@ -422,9 +425,10 @@ def start_promptinject(target_model: LLM, parameters: dict) -> AttackResult:
     lighter version of the official PromptInject, running 100 prompts instead
     of thousands.
     """
-    pi_probes = ['probes.promptinject.HijackHateHumans',
-                 'probes.promptinject.HijackKillHumans',
-                 'probes.promptinject.HijackLongPrompt',
+    # TODO: review probes from v0.11 as they will not be named Mini anymore
+    pi_probes = ['probes.promptinject.HijackHateHumansMini',
+                 'probes.promptinject.HijackKillHumansMini',
+                 'probes.promptinject.HijackLongPromptMini',
                  ]
 
     outfile = parameters.get('output_file', f'{OUTPUT_FILE}.promptinject')

--- a/backend-agent/libs/garak.py
+++ b/backend-agent/libs/garak.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import os
+import re
 from pathlib import Path
 from typing import List, Union
 
@@ -84,11 +85,10 @@ def run_garak(target_model: LLM, probes: list,
     """TODO"""
     # At runtime, garak appends ".report.jsonl" to any output filename the user
     # may decide to use, so we clean possible extensions here
-    output_filename = output_filename.rstrip('.jsonl')
-    output_filename = output_filename.rstrip('.json')
+    output_filename = re.sub(r'\.jsonl?$', '', output_filename)
     # After removing extensions, remove possible "report" before so not to have
     # it duplicated at runtime
-    output_filename = output_filename.rstrip('report')
+    output_filename = re.sub(r'report$', '', output_filename)
     # Remove possible trailing .
     output_filename = output_filename.rstrip('.')
     if not output_filename:

--- a/backend-agent/libs/garak.py
+++ b/backend-agent/libs/garak.py
@@ -21,7 +21,12 @@ logger.addHandler(status.trace_logging)
 
 OUTPUT_FILE = 'garak.stars'
 DESCRIPTION = """
-TODO
+Garak is a vulnerability scanner for LLMs. Garak probes for hallucination,
+data leakage, prompt injection, misinformation, toxicity generation,
+jailbreaks, and many other weaknesses. Attacks integrated into this tool are
+not original ones, but taken from the literature and reimplemented.
+In the context of STARS, we will use Garak as a vector to access a subset of
+such attacks (only the ones adapted to our working scenario).
 """
 # ############################### Adapter class ###############################
 
@@ -56,7 +61,11 @@ class SAPAICoreGenerator(Generator):
 # ################################## Attacks ##################################
 
 def _configure_garak(model_name: str, output_filename: str):
-    """ TODO """
+    """Configure garak.
+
+    This step is same for any attack we may want to run using Garak.
+    We load a pre-defined configuration to connect to AI Core models and set
+    the output file report."""
     _config.transient.starttime = datetime.datetime.now()
     _config.transient.starttime_iso = _config.transient.starttime.isoformat()
 
@@ -82,7 +91,14 @@ def _configure_garak(model_name: str, output_filename: str):
 
 def run_garak(target_model: LLM, probes: list,
               output_filename: str = OUTPUT_FILE):
-    """TODO"""
+    """Run a list of attacks (probes) from Garak attack framework.
+
+    @params
+    target_model: Model that is to be attacked.
+    probes: A list of attacks to run.
+    Additional parameters:
+    Optional parameter output_filename to set the output file of results.
+    """
     # At runtime, garak appends ".report.jsonl" to any output filename the user
     # may decide to use, so we clean possible extensions here
     output_filename = re.sub(r'\.jsonl?$', '', output_filename)
@@ -146,8 +162,20 @@ def run_garak(target_model: LLM, probes: list,
 
 
 def start_dan(target_model: LLM, parameters: dict) -> AttackResult:
+    """Start a DAN attack using Garak attack framework.
+
+    @params
+    target_model: Model that is to be attacked.
+    parameters: Additional parameters:
+    Optional parameter output_file to set the output file of results.
     """
-    TODO
+
+    dan_description = """DAN (Do Anything Now) is a prompt injection attack
+    that uses static prompts specifically crafted to try and bypass the
+    built-in safety, ethical, or content filtering mechanisms of LLMs.
+    We leverage 11 sub-probes from Garak to run this attack.
+    Each of these 11 sub-probes come with their community-developed static
+    prompt(s).
     """
     dan_probes = ['probes.dan.Dan_11_0',
                   'probes.dan.Dan_10_0',
@@ -157,8 +185,8 @@ def start_dan(target_model: LLM, parameters: dict) -> AttackResult:
                   'probes.dan.Dan_6_0',
                   'probes.dan.Dan_6_2',
                   'probes.dan.DUDE',
-                  'probes.dan.DUDESTAN',
-                  'probes.dan.DUDEAutoDANCached',
+                  'probes.dan.STAN',
+                  'probes.dan.AutoDANCached',
                   # TODO: rename it to DanInTheWild from garak v0.11
                   'probes.dan.DanInTheWildMini',
                   ]
@@ -174,8 +202,6 @@ def start_dan(target_model: LLM, parameters: dict) -> AttackResult:
         'prompt-injection',
         {
             'successful_attacks': results,
-            # TODO: the description should be extended to reflect the dan
-            # attack here
-            'attack_description': DESCRIPTION
+            'attack_description': dan_description
         }
     )

--- a/backend-agent/requirements.txt
+++ b/backend-agent/requirements.txt
@@ -23,3 +23,4 @@ pyrit==0.2.1
 textattack>=0.3.10
 codeattack @ git+https://github.com/marcorosa/CodeAttack
 gptfuzzer @ git+https://github.com/marcorosa/GPTFuzz@no-vllm
+garak~=0.10.3

--- a/backend-agent/tools.py
+++ b/backend-agent/tools.py
@@ -161,6 +161,39 @@ def run_artprompt(target_model_name: str,
         params={'num_prompts': num_prompts}).start())
 
 
+@tool
+def run_garak_attack(
+    attack_name: str,
+    target_model_name: str,
+) -> str:
+    """
+    Use this function to start an attack using the garak framework.
+    Run garak_how before running this function. Some attacks may need
+    different parameters.
+    @params
+    attack_name: Since garak supports many attacks, the name of the
+    attack must be specified here.
+    target_model_name: The name of the model to be attacked.
+    """
+
+    attack = attack_name.lower()
+    supported_attacks = ['dan',
+                         'encoding',
+                         'goodside',
+                         'latentinjection',
+                         'malwaregen',
+                         'phrasing',
+                         'promptinject',
+                         'suffix']
+    if attack not in supported_attacks:
+        return f'The attack "{attack}" is not available. \
+        Supported attacks are: {",".join(supported_attacks)}'
+
+    return str(AttackSpecification.create(
+        attack,
+        target=target_model_name).start())
+
+
 # *************************************************************************** #
 # *                         HF NLP attacks tools                            * #
 # *************************************************************************** #


### PR DESCRIPTION
This PR adds garak as a tool that can be run from STARS.
Not all Garak's probes are supported by STARS, as many of them fall outside our working scenario. Thus, only the ones related to prompt injection, jailbreak, system prompt leak and insecure code generation have been integrated. 
This is to say, the following:
- dan
- encoding
- goodside
- latentinjection
- malwaregen
- phrasing
- promptinject
- suffix

## Still TODOs:
- [ ] Wait for garak new release in pypi
- [ ] add garak in our requirements (requires patch https://github.com/NVIDIA/garak/pull/1171 to be released)