### PR TITLE
Fix artprompt missing english stopwords bug

### DIFF
--- a/backend-agent/libs/artprompt.py
+++ b/backend-agent/libs/artprompt.py
@@ -45,6 +45,18 @@ ArtPrompt malicious prompts are a subset of the AdvBench Harmful Behavior
 dataset, and relies on a LLM to judge whether the attack was successful.
 """
 
+# Ensure NLTK stopwords data is available, download if necessary
+try:
+    # Try to access stopwords to see if data exists
+    stopwords.words('english')
+except LookupError:
+    # Data doesn't exist, download it
+    logger.warning('Downloading NLTK (missing) stopwords data...')
+    import nltk
+    nltk.download('stopwords', quiet=True)
+    logger.debug('NLTK stopwords data downloaded successfully.')
+
+
 ##############################################################################
 # Content for cloaked prompt generation
 # ASCII letters generated with GPT

--- a/backend-agent/main.py
+++ b/backend-agent/main.py
@@ -27,7 +27,8 @@ app = create_app()
 # Configure CORS with allowed origins, if any
 allowed_origins = os.getenv('ALLOWED_ORIGINS', '').split(',')
 # Clean up empty strings from allowed_origins
-allowed_origins = [origin.strip() for origin in allowed_origins if origin.strip()]
+allowed_origins = [origin.strip() for origin in allowed_origins
+                   if origin.strip()]
 # Configure CORS
 if allowed_origins:
     CORS(app, resources={r"/*": {"origins": allowed_origins}})


### PR DESCRIPTION
Fresh installation of STARS (e.g., docker containers) suffers from a bug where running ArtPrompt raises a runtime exception due to missing English stopwords (`nltk.stopwords` with English data).

This PR patches the bug.